### PR TITLE
update docker image to use harden version and dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,23 @@
-FROM python:3.12-slim
+#syntax=docker/dockerfile:1
+
+FROM dhi.io/python:3.13-alpine3.22
 
 WORKDIR /app
-COPY . ./
 
-# System Prerequistes
-RUN apt-get update
-
-# System Depedencies
-RUN apt-get install -y --no-install-recommends \
-  gettext \
-  vim \
-  && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Create non-root user and set permissions
-RUN useradd -m appuser && chown -R appuser /app
-USER appuser
+# Copy requirements first for better caching
+COPY requirements.txt /app/
 
 # Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+RUN ["pip", "install", "--no-cache-dir", "-r", "/app/requirements.txt"]
+
+# Copy application code
+COPY . .
 
 # Set logo path as build argument and environment variable
 ARG LOGO_PATH=../static/img/logo.png
 ENV LOGO_PATH=${LOGO_PATH}
+
+# Use non-root user by default in DHI
+USER nonroot
 
 CMD ["python", "-u", "main.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.2.5
-Jinja2==3.1.3
+Flask==3.1.0
+Jinja2==3.1.5
 python-dotenv==1.0.1
-uvicorn==0.15.0
+uvicorn==0.34.0
 # Development dependencies
-flake8==5.0.4
+flake8==7.1.1


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve image efficiency, security, and maintainability. The main changes include switching to a lighter base image, optimizing the build process for better caching, and standardizing user permissions.

**Docker image improvements:**

* Switched the base image from `python:3.12-slim` to `dhi.io/python:3.13-alpine3.22`, resulting in a smaller and more secure image.
* Reordered `COPY` instructions to copy `requirements.txt` first, enabling Docker layer caching for dependencies.
* Changed the way Python dependencies are installed, using a JSON array form for the `RUN` command for improved reliability.

**Security and user management:**

* Replaced manual user creation with the default non-root user provided by the DHI image, improving security and simplifying the Dockerfile.

**General cleanup:**

* Removed unnecessary system package installations (`gettext`, `vim`) and related apt-get commands, reducing image size and complexity.